### PR TITLE
"Add" Subcommand

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -28,5 +28,7 @@ var addCmd = &cobra.Command{
 func init() {
     rootCmd.AddCommand(addCmd)
 
-    // TODO add flags
+    // TODO add name flag, this may have to be done after adjustment to yaml file reading
+    //  to allow name of template to be different from name of file
+    addCmd.Flags().StringP("name", "n", "", "Name for template") 
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -32,11 +32,16 @@ var addCmd = &cobra.Command{
         // get viper configurations(?)
         config := config.NewConfig()
 
-        // attempt to copy/cache template file
-        dstPath := template.CacheTemplateFile(args[0], &config)
 
         // parse/validate provided template
+        if _, err := template.NewTemplate(args[0], "", "", &config); err != nil {
+            fmt.Printf("Proivded file(%s) does not validate.\n", args[0])
+            return
+        }
 
+
+        // attempt to copy/cache template file
+        dstPath := template.CacheTemplateFile(args[0], &config)
         
         // add template to config with viper
         v := viper.GetString("templates."+templateName)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,8 +1,14 @@
 package cmd
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/calebcscott/pkg-init/pkg/config"
+	"github.com/calebcscott/pkg-init/pkg/template"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 
@@ -13,14 +19,39 @@ var addCmd = &cobra.Command{
     Args: cobra.ExactArgs(1),
     Run: func(cmd *cobra.Command, args []string) {
         //TODO add logic to add template 
+        templateName, _ := cmd.Flags().GetString("name")
+        _, fileName := filepath.Split(args[0])
+        if templateName == "" {
+            templateName = strings.Split(fileName, ".")[0]
+        }
+        lang, _ := cmd.Flags().GetString("lang")
+
+        fmt.Println("Adding template:", templateName)
+        fmt.Println("for language type:", lang)
 
         // get viper configurations(?)
-        _ = config.NewConfig()
+        config := config.NewConfig()
 
+        // attempt to copy/cache template file
+        dstPath := template.CacheTemplateFile(args[0], &config)
 
         // parse/validate provided template
 
+        
         // add template to config with viper
+        v := viper.GetString("templates."+templateName)
+        if v != "" {
+            if !template.GetChoiceB("Overrideing template: "+v+", Do you want to continue?[Y/n]") {
+                return
+            }
+
+        }
+        viper.Set("templates."+templateName, dstPath)
+
+        err := viper.WriteConfig()
+        if err != nil {
+            fmt.Println("Error writing config")
+        }
     },
 }
 
@@ -31,4 +62,5 @@ func init() {
     // TODO add name flag, this may have to be done after adjustment to yaml file reading
     //  to allow name of template to be different from name of file
     addCmd.Flags().StringP("name", "n", "", "Name for template") 
+    addCmd.Flags().StringP("lang", "l", "", "Language/Project type for template") 
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -10,7 +10,7 @@ var addCmd = &cobra.Command{
     Use: "add",
     Short: "Add a project template",
     Long: "Adds a project template so that it can be used shorthand.",
-    Args: cobra.MaximumNArgs(1),
+    Args: cobra.ExactArgs(1),
     Run: func(cmd *cobra.Command, args []string) {
         //TODO add logic to add template 
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"github.com/calebcscott/pkg-init/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+
+var addCmd = &cobra.Command{
+    Use: "add",
+    Short: "Add a project template",
+    Long: "Adds a project template so that it can be used shorthand.",
+    Args: cobra.MaximumNArgs(1),
+    Run: func(cmd *cobra.Command, args []string) {
+        //TODO add logic to add template 
+
+        // get viper configurations(?)
+        _ = config.NewConfig()
+
+
+        // parse/validate provided template
+
+        // add template to config with viper
+    },
+}
+
+
+func init() {
+    rootCmd.AddCommand(addCmd)
+
+    // TODO add flags
+}

--- a/pkg-init.yaml
+++ b/pkg-init.yaml
@@ -1,12 +1,12 @@
 
-
-data-dir: /usr/share/pkg-int/etc
+# can be ommitted and will default to UserCacheDir || ~/.cache/pkg-init
+data-dir: ~/.cache/pkg-init
 languages:
   c: default
   c++: default
 templates:
   default: default
-  test: ./test.yaml
+  working: ./test/working.yaml
 default:
   type: raw
   commands: |

--- a/pkg/config/pkgconfig.go
+++ b/pkg/config/pkgconfig.go
@@ -1,6 +1,11 @@
 package config
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/spf13/viper"
 )
 
@@ -13,7 +18,28 @@ type PkgConfig struct {
 
 
 func NewConfig() PkgConfig {
+    var err error
+
+
     cache := viper.GetString("data-dir")
+    if cache != "" {
+        home := os.Getenv("HOME")
+        replacer := strings.NewReplacer("~", home, "${home}", home)
+        cache = replacer.Replace(cache)
+
+    } else {
+        cache, err = os.UserCacheDir()
+        if err != nil {
+            fmt.Println("Could not find suitable cache, defaulting to ~/.cache")
+            cache = "~/.cache"
+        }
+
+        cache = filepath.Join(cache, "pkg-init")
+    }
+    if _, err := os.Stat(cache); err != nil {
+        fmt.Println("Attempting to ensure cache dir exists: ", cache)
+        os.MkdirAll(cache, 0755)
+    }
     templateMap := viper.GetStringMapString("templates")
     langs := viper.GetStringMapString("languages")
 

--- a/pkg/template/handler.go
+++ b/pkg/template/handler.go
@@ -73,7 +73,7 @@ func (th *TemplateHandler) Init(config *config.PkgConfig) error {
 }
 
 
-func NewTemplate(name string, lang string, dir string, config *config.PkgConfig) (TemplateHandler, error) {
+func NewTemplate(name string, lang string, dir string, config *config.PkgConfig) (*TemplateHandler, error) {
     var template template
     var err error
     if lang != "" {
@@ -89,10 +89,10 @@ func NewTemplate(name string, lang string, dir string, config *config.PkgConfig)
     
 
     if err != nil {
-        return TemplateHandler{}, err
+        return nil, err
     }
 
-    return TemplateHandler{
+    return &TemplateHandler{
         Name: name,
         language: lang,
         directory: dir,

--- a/pkg/template/handler.go
+++ b/pkg/template/handler.go
@@ -50,7 +50,7 @@ func getChoiceB(msg string) bool {
     }
 }
 
-func (th TemplateHandler) Init(config *config.PkgConfig) error {
+func (th *TemplateHandler) Init(config *config.PkgConfig) error {
     fmt.Println("Initializing template", th.Name, "in directory", th.directory)
 
     empty, err := IsEmpty(th.directory)

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -103,7 +103,8 @@ func newCommand(cmds string) (cmd, error) {
 
     return cmd{ commands }, nil
 }
-func (c cmd) run (dir string) error {
+
+func (c *cmd) run (dir string) error {
 
     if len(c.cmds) == 0 {
         return nil
@@ -125,16 +126,16 @@ func (c cmd) run (dir string) error {
     return nil
 }
 
-func newTemplateContent(temp map[string]interface{}) (templateContent, error) {
+func newTemplateContent(temp map[string]interface{}) (*templateContent, error) {
 
     // pull out contents
     contents, found := temp["contents"]
 
     if !found {
-        return templateContent{}, errors.New("malformed template, no contents found")
+        return nil, errors.New("malformed template, no contents found")
     }
     if err:= validateTemplate(contents); err != nil {
-        return templateContent{}, err
+        return nil, err
     }
 
     // pull out commands, optional field
@@ -145,11 +146,11 @@ func newTemplateContent(temp map[string]interface{}) (templateContent, error) {
     }
     cmd, err := newCommand(commands.(string))
     if err != nil {
-        return templateContent{}, err
+        return nil, err
     }
 
 
-    return templateContent{contents.(map[string]interface{}), cmd }, nil
+    return &templateContent{contents.(map[string]interface{}), cmd }, nil
 }
 
 
@@ -226,7 +227,7 @@ func buildTemplate(contentMap interface{}, tld string) error {
     return err
 }
 
-func (t templateContent) build( config *config.PkgConfig, tld string ) error {
+func (t *templateContent) build( config *config.PkgConfig, tld string ) error {
     // attempt to build template
     if err := buildTemplate(t.contents, tld); err != nil {
         return err

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -134,7 +134,7 @@ func newTemplateContent(temp map[string]interface{}) (*templateContent, error) {
     if !found {
         return nil, errors.New("malformed template, no contents found")
     }
-    if err:= validateTemplate(contents); err != nil {
+    if err:= validateTemplateContents(contents); err != nil {
         return nil, err
     }
 
@@ -161,14 +161,14 @@ func newTemplateContent(temp map[string]interface{}) (*templateContent, error) {
     Do not need to pass a Top-Level-Directory / Prefix since we
         do not do any path validation, only template validation
 */
-func validateTemplate(contentMap interface{}) error {
+func validateTemplateContents(contentMap interface{}) error {
     switch  contentMap := contentMap.(type) {
     // empty case for string []interface{} since we expect those
     case string:
     case []interface{}:
     case map[string]interface{}:
         for _, contents := range contentMap {
-            validateTemplate(contents)
+            validateTemplateContents(contents)
         }
     default:
         return errors.New("malformed template")

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -155,7 +155,7 @@ func newTemplateContent(temp map[string]interface{}) (*templateContent, error) {
 
 
 /*
-    validate_template
+    validateTemplateContents
 
     Validate whether supplied template matches expected contents
     Do not need to pass a Top-Level-Directory / Prefix since we
@@ -182,7 +182,7 @@ func validateTemplateContents(contentMap interface{}) error {
 
     Still need to return possible errors with directory or file names/creation
 */
-func buildTemplate(contentMap interface{}, tld string) error {
+func buildTemplateContents(contentMap interface{}, tld string) error {
     var err error = nil
     switch  contentMap := contentMap.(type) {
     case string:
@@ -215,7 +215,7 @@ func buildTemplate(contentMap interface{}, tld string) error {
             // recurse to pick up files/subdirs if no error
             // cannot recurse if error'd on dir creation
             if dirErr == nil {
-                subErr := buildTemplate(contents, newTld)
+                subErr := buildTemplateContents(contents, newTld)
 
                 if err == nil {
                     err = subErr
@@ -229,7 +229,7 @@ func buildTemplate(contentMap interface{}, tld string) error {
 
 func (t *templateContent) build( config *config.PkgConfig, tld string ) error {
     // attempt to build template
-    if err := buildTemplate(t.contents, tld); err != nil {
+    if err := buildTemplateContents(t.contents, tld); err != nil {
         return err
     }
 

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -25,7 +25,7 @@ func Test_newTemplateContent_BadInput(t *testing.T) {
 
     tc, err := newTemplateContent(emptyMap)
 
-    if len(tc.contents) != 0 || err == nil {
+    if tc != nil || err == nil {
         t.Errorf("newTemplateContent failed, expected -> %v, got -> %v", templateContent{}, tc)
     }
 }

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -11,10 +11,10 @@ import (
 func Test_validateTemplate_BadInput(t *testing.T) {
     var emptyMap interface{}
 
-    err := validateTemplate(emptyMap)
+    err := validateTemplateContents(emptyMap)
 
     if err == nil {
-        t.Errorf("validateTemplate on empty map failed, expected error")
+        t.Errorf("validateTemplateContents on empty map failed, expected error")
     }
 }
 


### PR DESCRIPTION
This feature adds the ability to add template files to the `pkg-init` config structure to allow users to use the short hand `pkg-init init -t <template-name>` instead of `pkg-init init -t /path/to/teamplate.yml`

Closes #4 